### PR TITLE
Modify art printing, make pingu infinite

### DIFF
--- a/main.go
+++ b/main.go
@@ -151,7 +151,7 @@ func initPinger(host string) (*ping.Pinger, error) {
 
 // nolint:forbidigo
 func pingerOnrecv(pkt *ping.Packet) {
-	fmt.Printf("%s seq=%s %sbytes from %s: ttl=%s time=%s\n",
+	fmt.Printf("\r%s seq=%s %sbytes from %s: ttl=%s time=%s\n",
 		renderASCIIArt(pkt.Seq),
 		color.New(color.FgHiYellow, color.Bold).Sprintf("%d", pkt.Seq),
 		color.New(color.FgHiBlue, color.Bold).Sprintf("%d", pkt.Nbytes),
@@ -183,10 +183,10 @@ func pingerOnFinish(stats *ping.Statistics) {
 		color.New(color.FgMagenta, color.Bold).Sprintf("%v", stats.StdDevRtt),
 	)
 }
-
+	
 func renderASCIIArt(idx int) string {
 	if len(pingu) <= idx {
-		return strings.Repeat(" ", len(pingu[0]))
+		idx = idx % len(pingu)
 	}
 
 	line := pingu[idx]


### PR DESCRIPTION
1. Added a carriage return `\r` character before printing pingu art. This will ensure that all user-typed characters are cleared, and pingu art is printed from the start of the line.

**Before, Art is distorted 😦**

![Pingu - Before](https://user-images.githubusercontent.com/68515826/173430422-483b90e9-5632-4054-a3ed-821950893fa1.png)

**After, Art is consistent and clean 😃**

![Pingu - After](https://user-images.githubusercontent.com/68515826/173430624-89584f23-6845-4a0a-990d-095a79a38d6f.png)

2. Changed display logic, so that pingu is displayed repeatedly, not once

**Before, Single Pingu**

![Pingu - Before](https://user-images.githubusercontent.com/68515826/173431281-b9f9b3da-2cf8-4605-a1d4-bc6b8a514c00.png)

**After, Many Pingu!**

![Pingu - After](https://user-images.githubusercontent.com/68515826/173431544-c923dc9f-5f14-4653-934a-0432612a6092.png)
