### PR TITLE
docs: fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@
 ## Features
 
 - [x] Colorful and fun output.
-- [x] Cross-platform support: Windows, macOS and Linux (also WSL)
+- [x] Cross-platform support: Windows, macOS, and Linux (also WSL)
 - [x] It works with a single executable file, so it can be installed easily.
-- [x] Surpports IPv4 and IPv6.
+- [x] Support IPv4 and IPv6.
 
 ## Usage
 
@@ -87,4 +87,3 @@ pingu -P github.com
 ## Author
 
 [Sheepla](https://github.com/sheepla)
-


### PR DESCRIPTION
- L.25: macOS and Linux -> macOS, and Linux
- L.27: Surpports -> Support
  - Remove 's' to unify the word 'support' on L.25